### PR TITLE
DB Logic: Partial Matches for Pet Names

### DIFF
--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -129,6 +129,18 @@ RSpec.describe 'Application Show Page' do
           end
         end
       end
+
+      describe 'partial matches for pet names' do
+        describe 'search for pets by pet name' do
+          it 'lists any pet whose name partially matches' do
+            visit "/applications/#{@application_1.id}"
+            fill_in 'Search', with: "rus"
+            click_button 'Submit'
+
+            expect(page).to have_content("#{@pet_3.name}")
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Wrote passing test in show_spec for applications to be able to render search results from partial matches because the method for partial matches for searches was already written #search in the application_record.rb model that the other models inherit from. It is already tested in the model spec for pet. 