### PR TITLE
DB Logic: Shelters with Pending Applications

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,5 +1,6 @@
 class AdminController < ApplicationController
   def index
     @shelters = Shelter.all.by_name_reverse
+    @shelters_pending = Shelter.all.pending_apps
   end
 end

--- a/app/models/shelter.rb
+++ b/app/models/shelter.rb
@@ -20,6 +20,10 @@ class Shelter < ApplicationRecord
     find_by_sql("SELECT * FROM shelters ORDER BY name desc")
   end
 
+  def self.pending_apps
+    joins(pets: [:applications]).where(pets: {applications: {status: 'Pending'}})
+  end
+
   def pet_count
     pets.count
   end

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -2,3 +2,12 @@
 <% @shelters.each do |shelter| %>
   <p><%= shelter.name %></p>
 <% end %>
+
+<br>
+
+<section id = "pending">
+<h2>Shelters with Pending Applications</h2>
+  <%@shelters_pending.each do |shelter| %>
+    <p><%=shelter.name%></p>
+  <% end %>
+</section>

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -5,7 +5,7 @@
 
 <br>
 
-<section id = "pending">
+<section id="pending">
 <h2>Shelters with Pending Applications</h2>
   <%@shelters_pending.each do |shelter| %>
     <p><%=shelter.name%></p>

--- a/app/views/applications/_description.html.erb
+++ b/app/views/applications/_description.html.erb
@@ -2,7 +2,7 @@
   <%= form_with url: "/applications/#{@application.id}", method: :patch, local: true do |f| %>
     <%= f.label :description %>
     <br>
-    <%= f.text_field :description %>
+    <%= f.text_area :description, required: true %>
     <br>
     <%= f.submit 'Submit your application' %>
   <% end %>

--- a/spec/features/admin/index_spec.rb
+++ b/spec/features/admin/index_spec.rb
@@ -21,10 +21,18 @@ RSpec.describe 'Admin Shelters Index', type: :feature do
   end
 
   xit 'displays a section for shelters with pending applications' do
+    application_1 = Application.create!(applicant_name: Faker::Name.name, street_address: '131 Seward Lane', city: 'Longmont', state: 'Colorado', zip_code: '80501')
+    application_1 << @pet_1
+    visit "/applications/#{application_1.id}"
+    fill_in :search, with: "#{@pet_1.name}"
+    click_button 'Submit'
+    click_button "Adopt #{@pet_1.name}"
+    fill_in :description, with: 'Big, fenced backyard.'
+    click_button('Submit your application')
     visit '/admin/shelters'
 
     within("#pending-apps") do
-      expect(page).to have_content(@shelter_1)
+      expect(page).to have_content([@shelter_1.name])
     end
 
   end

--- a/spec/features/admin/index_spec.rb
+++ b/spec/features/admin/index_spec.rb
@@ -20,18 +20,12 @@ RSpec.describe 'Admin Shelters Index', type: :feature do
     expect(@shelter_1.name).to_not appear_before(@shelter_3.name)
   end
 
-  xit 'displays a section for shelters with pending applications' do
-    application_1 = Application.create!(applicant_name: Faker::Name.name, street_address: '131 Seward Lane', city: 'Longmont', state: 'Colorado', zip_code: '80501')
-    application_1 << @pet_1
-    visit "/applications/#{application_1.id}"
-    fill_in :search, with: "#{@pet_1.name}"
-    click_button 'Submit'
-    click_button "Adopt #{@pet_1.name}"
-    fill_in :description, with: 'Big, fenced backyard.'
-    click_button('Submit your application')
+  it 'displays a section for shelters with pending applications' do
+    application_1 = Application.create!(applicant_name: Faker::Name.name, street_address: '131 Seward Lane', city: 'Longmont', state: 'Colorado', zip_code: '80501', description: 'Huge backyard', status: 'Pending')
+    application_1.pets << @pet_1
     visit '/admin/shelters'
-
-    within("#pending-apps") do
+    save_and_open_page
+    within("section#pending") do
       expect(page).to have_content([@shelter_1.name])
     end
 

--- a/spec/features/admin/index_spec.rb
+++ b/spec/features/admin/index_spec.rb
@@ -24,9 +24,9 @@ RSpec.describe 'Admin Shelters Index', type: :feature do
     application_1 = Application.create!(applicant_name: Faker::Name.name, street_address: '131 Seward Lane', city: 'Longmont', state: 'Colorado', zip_code: '80501', description: 'Huge backyard', status: 'Pending')
     application_1.pets << @pet_1
     visit '/admin/shelters'
-    save_and_open_page
-    within("section#pending") do
-      expect(page).to have_content([@shelter_1.name])
+    
+    within("#pending") do
+      expect(page).to have_content(@shelter_1.name)
     end
 
   end

--- a/spec/features/admin/index_spec.rb
+++ b/spec/features/admin/index_spec.rb
@@ -19,4 +19,13 @@ RSpec.describe 'Admin Shelters Index', type: :feature do
     expect(@shelter_2.name).to appear_before(@shelter_3.name)
     expect(@shelter_1.name).to_not appear_before(@shelter_3.name)
   end
+
+  xit 'displays a section for shelters with pending applications' do
+    visit '/admin/shelters'
+
+    within("#pending-apps") do
+      expect(page).to have_content(@shelter_1)
+    end
+
+  end
 end

--- a/spec/models/shelter_spec.rb
+++ b/spec/models/shelter_spec.rb
@@ -48,17 +48,11 @@ RSpec.describe Shelter, type: :model do
       end
     end
 
-    describe '#pending_apps' do
+    describe '::pending_apps' do
       it 'returns the shelters that have pending applications' do
-        application_1 = Application.create!(applicant_name: Faker::Name.name, street_address: '131 Seward Lane', city: 'Longmont', state: 'Colorado', zip_code: '80501')
-        application_1 << @pet_1
-        visit "/applications/#{application_1.id}"
-        fill_in :search, with: "#{@pet_1.name}"
-        click_button 'Submit'
-        click_button "Adopt #{@pet_1.name}"
-        fill_in :description, with: 'Big, fenced backyard.'
-        click_button('Submit your application')
-        
+        application_1 = Application.create!(applicant_name: Faker::Name.name, street_address: '131 Seward Lane', city: 'Longmont', state: 'Colorado', zip_code: '80501', description: 'Huge backyard', status: 'Pending')
+        application_1.pets << @pet_1
+
         expect(Shelter.pending_apps).to eq([@shelter_1])
       end
     end

--- a/spec/models/shelter_spec.rb
+++ b/spec/models/shelter_spec.rb
@@ -47,6 +47,21 @@ RSpec.describe Shelter, type: :model do
         expect(Shelter.by_name_reverse).to eq([@shelter_2, @shelter_3, @shelter_1])
       end
     end
+
+    describe '#pending_apps' do
+      it 'returns the shelters that have pending applications' do
+        application_1 = Application.create!(applicant_name: Faker::Name.name, street_address: '131 Seward Lane', city: 'Longmont', state: 'Colorado', zip_code: '80501')
+        application_1 << @pet_1
+        visit "/applications/#{application_1.id}"
+        fill_in :search, with: "#{@pet_1.name}"
+        click_button 'Submit'
+        click_button "Adopt #{@pet_1.name}"
+        fill_in :description, with: 'Big, fenced backyard.'
+        click_button('Submit your application')
+        
+        expect(Shelter.pending_apps).to eq([@shelter_1])
+      end
+    end
   end
 
   describe 'instance methods' do


### PR DESCRIPTION
Created ::pending_apps for shelters, using a nested joins. 
May need to refactor to make sure if there is more than one app in for the shelter, its name only shows once? 

Within block in admin index feature test tests the list of pending apps shelters separately from the list of all shelters. 