### PR TITLE
User Story: Approved/Rejected Pets on one Application do not affect other Applications

### DIFF
--- a/spec/features/admin/applications/show_spec.rb
+++ b/spec/features/admin/applications/show_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Admin application show page' do
     @application_3 = Application.create!(applicant_name: 'Gerald F', street_address: '1775 Spencer Street', city: 'Longmont', state: 'Colorado', zip_code: '80501', description: 'I love animals!', status: "In Progress")
     @pet_app_1 = PetApplication.create(pet_id: @pet_4.id, application_id: @application_1.id)
     @pet_app_1 = PetApplication.create(pet_id: @pet_8.id, application_id: @application_1.id)
-    @pet_app_2 = PetApplication.create(pet_id: @pet_1.id, application_id: @application_2.id)
+    @pet_app_2 = PetApplication.create(pet_id: @pet_4.id, application_id: @application_2.id)
     @pet_app_3 = PetApplication.create(pet_id: @pet_2.id, application_id: @application_3.id)
   end
 
@@ -50,6 +50,22 @@ RSpec.describe 'Admin application show page' do
       expect(page).to have_button("Reject application for #{@pet_8.name}")
       expect(page).to have_button("Approve application for #{@pet_8.name}")
       expect(page).to have_content("#{@pet_4.name}: Rejected")
+    end
+  end
+
+  describe 'approved or rejected pets on one application to not affect other applications' do
+    it 'does not matter if there are two applications for the same pet' do
+      visit "/admin/applications/#{@application_1.id}"
+      click_button "Reject application for #{@pet_4.name}"
+      expect(current_path).to eq("/admin/applications/#{@application_1.id}")
+      expect(page).to_not have_button("Reject application for #{@pet_4.name}")
+      expect(page).to_not have_button("Approve application for #{@pet_4.name}")
+      expect(page).to have_content("#{@pet_4.name}: Rejected")
+
+      visit "/admin/applications/#{@application_2.id}"
+      expect(current_path).to eq("/admin/applications/#{@application_2.id}")
+      expect(page).to have_button("Reject application for #{@pet_4.name}")
+      expect(page).to have_button("Approve application for #{@pet_4.name}")
     end
   end
 end


### PR DESCRIPTION
Added test to show that two applications can be for the same pet and if I approve or reject one application's pet, I still see the buttons to approve or reject that pet on the other application (as an admin). 